### PR TITLE
Add support for data_subdir kernel cmdline argument

### DIFF
--- a/init-script
+++ b/init-script
@@ -118,13 +118,15 @@ bootsplash() {
 mount_stowaways() {
     echo "########################## mounting stowaways"
     if [ ! -z $DATA_PARTITION ]; then
+        data_subdir="$(get_opt data_subdir)"
+
 	mkdir /data
 	mkdir /target
 
 	mount $DATA_PARTITION /data
-	mount --bind /data/.stowaways/${DEFAULT_OS} /target
+	mount --bind /data/${data_subdir}/.stowaways/${DEFAULT_OS} /target
 	mkdir /target/data # in new fs
-	mount --bind /data /target/data
+	mount --bind /data/${data_subdir} /target/data
     else
         echo "Failed to mount /target, device node '$DATA_PARTITION' not found!" >> /diagnosis.log
     fi


### PR DESCRIPTION
- Enables having the system in subdir of the /data
  partition, useful when multibooting
- This modification is currently used by [MultiROM](http://forum.xda-developers.com/google-nexus-5/orig-development/mod-multirom-v24-t2571011),
  a multiboot modification for several Nexus
  devices.
