### PR TITLE
Fix infinite loop when fstab is not found. Improve finding fstab files.

### DIFF
--- a/Android.mk
+++ b/Android.mk
@@ -45,6 +45,19 @@ HYBRIS_FIXUP_MOUNTS := $(LOCAL_PATH)/fixup-mountpoints
 # TARGET_VENDOR := $(shell echo $(PRODUCT_MANUFACTURER) | tr '[:upper:]' '[:lower:]')
 # but Cyanogenmod seems to use device/*/$(TARGET_DEVICE) in config.mk so we will too.
 HYBRIS_FSTABS := $(shell find device/*/$(TARGET_DEVICE) -name *fstab* | grep -v goldfish)
+# If fstab files were not found from primary device repo then they might be in
+# some other device repo so try to search for them first in device/PRODUCT_MANUFACTURER. 
+# In many cases PRODUCT_MANUFACTURER is the short vendor name used in folder names.
+ifeq "$(HYBRIS_FSTABS)" ""
+TARGET_VENDOR := "$(shell echo $(PRODUCT_MANUFACTURER) | tr '[:upper:]' '[:lower:]')"
+HYBRIS_FSTABS := $(shell find device/$(TARGET_VENDOR) -name *fstab* | grep -v goldfish)
+endif
+# Some devices devices have the short vendor name in PRODUCT_BRAND so try to
+# search from device/PRODUCT_BRAND if fstab files are still not found.
+ifeq "$(HYBRIS_FSTABS)" ""
+TARGET_VENDOR := "$(shell echo $(PRODUCT_BRAND) | tr '[:upper:]' '[:lower:]')"
+HYBRIS_FSTABS := $(shell find device/$(TARGET_VENDOR) -name *fstab* | grep -v goldfish)
+endif
 
 # Get the unique /dev field(s) from the line(s) containing the fs mount point
 # Note the perl one-liner uses double-$ as per Makefile syntax

--- a/Android.mk
+++ b/Android.mk
@@ -48,8 +48,8 @@ HYBRIS_FSTABS := $(shell find device/*/$(TARGET_DEVICE) -name *fstab* | grep -v 
 
 # Get the unique /dev field(s) from the line(s) containing the fs mount point
 # Note the perl one-liner uses double-$ as per Makefile syntax
-HYBRIS_BOOT_PART := $(shell /usr/bin/perl -w -e '$$fs=shift; while (<>) { next unless /^$$fs\s|\s$$fs\s/;for (split) {next unless m(^/dev); print "$$_\n"; }}' /boot $(HYBRIS_FSTABS) | sort -u)
-HYBRIS_DATA_PART := $(shell /usr/bin/perl -w -e '$$fs=shift; while (<>) { next unless /^$$fs\s|\s$$fs\s/;for (split) {next unless m(^/dev); print "$$_\n"; }}' /data $(HYBRIS_FSTABS) | sort -u)
+HYBRIS_BOOT_PART := $(shell /usr/bin/perl -w -e '$$fs=shift; if ($$ARGV[0]) { while (<>) { next unless /^$$fs\s|\s$$fs\s/;for (split) {next unless m(^/dev); print "$$_\n"; }}} else { print "ERROR: *fstab* not found\n";}' /boot $(HYBRIS_FSTABS) | sort -u)
+HYBRIS_DATA_PART := $(shell /usr/bin/perl -w -e '$$fs=shift; if ($$ARGV[0]) { while (<>) { next unless /^$$fs\s|\s$$fs\s/;for (split) {next unless m(^/dev); print "$$_\n"; }}} else { print "ERROR: *fstab* not found\n";}' /data $(HYBRIS_FSTABS) | sort -u)
 
 $(warning ********************* /boot appears to live on $(HYBRIS_BOOT_PART))
 $(warning ********************* /data appears to live on $(HYBRIS_DATA_PART))


### PR DESCRIPTION
Fixes infinite loop when fstab is not found. This happens for example for devices with fstab file(s) in an extra device repo instead of the main device repo. To improve finding fstab files search for the files also in other device repos of same vendor if fstab files were not found in primary device repo.