### PR TITLE
[tools] Build img2simg_host and simg2img_host for hybris-hal 

### DIFF
--- a/Android.mk
+++ b/Android.mk
@@ -234,5 +234,5 @@ HYBRIS_UPDATER_UNPACK := $(LOCAL_BUILD_MODULE)
 
 
 .PHONY: hybris-hal
-hybris-hal: bootimage hybris-updater-unpack hybris-updater-script hybris-recovery hybris-boot linker init libc adb adbd libEGL libGLESv2 servicemanager logcat updater
+hybris-hal: bootimage hybris-updater-unpack hybris-updater-script hybris-recovery hybris-boot img2simg_host simg2img_host linker init libc adb adbd libEGL libGLESv2 servicemanager logcat updater
 


### PR DESCRIPTION
When doing image creation in OBS or mic, the default image creation
tools from droid-hal-tools package don't always work if the device
requires special version of those tools.

Let's build all the tools: img2simg, simg2img, and mkbootimg always
with hybris-hal, so they can easily be packaked in droid-hal-device
to a separate device specific tools package. Please note mkbootimg
is already required by hybris-boot, so no special dependency was
added for it.

Signed-off-by: Kalle Jokiniemi <kalle.jokiniemi@jolla.com>