### PR TITLE
Revert "[tools] Build img2simg_host and simg2img_host for hybris-hal"

### DIFF
--- a/Android.mk
+++ b/Android.mk
@@ -234,5 +234,5 @@ HYBRIS_UPDATER_UNPACK := $(LOCAL_BUILD_MODULE)
 
 
 .PHONY: hybris-hal
-hybris-hal: bootimage hybris-updater-unpack hybris-updater-script hybris-recovery hybris-boot img2simg_host simg2img_host linker init libc adb adbd libEGL libGLESv2 servicemanager logcat updater
+hybris-hal: bootimage hybris-updater-unpack hybris-updater-script hybris-recovery hybris-boot linker init libc adb adbd libEGL libGLESv2 servicemanager logcat updater
 


### PR DESCRIPTION
This reverts commit cde067a1d613a88209b1ecf8c955019425e16315.

If one needs OBS packaged special version of droid-hal-tools,
the correct way is to branch a version of droid-hal-tools
and modify it to build the correct version of tools.

Signed-off-by: Kalle Jokiniemi <kalle.jokiniemi@jolla.com>