### PR TITLE
libGLESv1_CM also needs to be built by hybris-hal

### DIFF
--- a/Android.mk
+++ b/Android.mk
@@ -234,5 +234,5 @@ HYBRIS_UPDATER_UNPACK := $(LOCAL_BUILD_MODULE)
 
 
 .PHONY: hybris-hal
-hybris-hal: bootimage hybris-updater-unpack hybris-updater-script hybris-recovery hybris-boot linker init libc adb adbd libEGL libGLESv2 servicemanager logcat updater
+hybris-hal: bootimage hybris-updater-unpack hybris-updater-script hybris-recovery hybris-boot linker init libc adb adbd libEGL libGLESv1_CM libGLESv2 servicemanager logcat updater
 


### PR DESCRIPTION
because it relies on the OpenGL TLS slot
libhybris glesv1 implementation also has to be changed (TODO) to load the correct version of libGLESv1_CM.so

Change-Id: Ic1d9130f4e2edd187ed9fd1aa15db4391f2be074