### PR TITLE
Fix USB networking on devices with both usb0 and rndis0 interfaces.

### DIFF
--- a/init-script
+++ b/init-script
@@ -216,8 +216,10 @@ run_debug_session() {
     usb_setup "Mer Debug setting up (DONE_SWITCH=$DONE_SWITCH)"
 
     USB_IFACE=notfound
-    /sbin/ifconfig usb0   $LOCAL_IP && USB_IFACE=usb0
     /sbin/ifconfig rndis0 $LOCAL_IP && USB_IFACE=rndis0
+    if [ x$USB_IFACE = xnotfound ]; then
+        /sbin/ifconfig usb0 $LOCAL_IP && USB_IFACE=usb0
+    fi
     # Report for the logs
     /sbin/ifconfig -a
 


### PR DESCRIPTION
Some devices have both usb0 and rndis0 interfaces and enabling them both with the same IP address will cause USB networking to fail. Current experience tells that rndis0 should be preferred in this situation so let's make usb0 interface initialized only if rndis0 initialization fails.