### PR TITLE
[updater] check that filesystem is extracted successfully

### DIFF
--- a/updater-script
+++ b/updater-script
@@ -24,7 +24,7 @@ package_extract_file("updater-unpack.sh", "/tmp/updater-unpack.sh");
 
 ui_print("Running installation script ...");
 %SET_PERMISSIONS%
-run_program("/tmp/updater-unpack.sh");
+run_program("/tmp/updater-unpack.sh") == "0" || abort("Failed to extract filesystem!");
 
 ui_print("Flashing hybris-boot.img ...");
 package_extract_file("hybris-boot.img", "%BOOT_PART%");

--- a/updater-unpack.sh
+++ b/updater-unpack.sh
@@ -6,6 +6,8 @@ FS_DST="/data/.stowaways/sailfishos"
 rm -rf $FS_DST
 mkdir -p $FS_DST
 tar --numeric-owner -xvjf $FS_ARC -C $FS_DST
+EXIT=$?
 
 rm $FS_ARC
 
+exit $EXIT


### PR DESCRIPTION
Extracting filesystem tarball can fail for various reasons
(e.g. no space left on /data partition). Check that extracting
files was successful or abort installation otherwise.