### PR TITLE
[sirius] add detection to fixup-mountpoints

### DIFF
--- a/fixup-mountpoints
+++ b/fixup-mountpoints
@@ -156,9 +156,10 @@ case "$DEVICE" in
             -e 's block/platform/msm_sdcc.1/by-name/LTALabel mmcblk1 ' \
             "$@"
         ;;
-    "z3c")
-    # Also called "aries" | "d5803" in aosp (called z3c in cm12.1)
-    # untested for | "sirius" | "amami" | "leo" | "tianchi")
+    "z3c" | "sirius")
+    # Z3 compact is also called "aries" | "d5803" in aosp (called z3c in cm12.1)
+    # Z2 is also called "d6503" in aosp (called sirius in cm12.1)
+    # untested for "amami" | "leo" | "tianchi")
          sed -i \
              -e 's block/platform/msm_sdcc.1/by-name/DDR mmcblk0p17 ' \
              -e 's block/platform/msm_sdcc.1/by-name/FOTAKernel mmcblk0p16 ' \


### PR DESCRIPTION
Z3 Compact has kernel unified with Z2, therefore mountpoints are the same. Should be same for Z3 and Z2 Tablet as well, as they are all shinano.
