### PR TITLE
[i9100g] Add Samsung Galaxy S2 G to fixup mountpoints

### DIFF
--- a/fixup-mountpoints
+++ b/fixup-mountpoints
@@ -97,7 +97,7 @@ case "$DEVICE" in
 	    "$@"
 	;;
 
-    "p3100" | "p3110" | "p3113" | "p5100" | "p5110" | "p5113" | "espressowifi" | "espresso3g")
+    "p3100" | "p3110" | "p3113" | "p5100" | "p5110" | "p5113" | "espressowifi" | "espresso3g" | "i9100g")
         sed -i \
             -e 's block/platform/omap/omap_hsmmc.1/by-name/DATAFS mmcblk0p10 ' \
             -e 's block/platform/omap/omap_hsmmc.1/by-name/KERNEL mmcblk0p5 ' \


### PR DESCRIPTION
i9100g uses the same processor as galaxy tab 2 (omap4430) so the mountpoints are the same
take note that i9100g (omap based) is different from i9100 (exynos based)

Change-Id: I67c0240d31e68b131d98b00ff6d899c113fdeef7