### PR TITLE
Add support for configfs based devices, add support for android 8, add pioneer to fixup-mountpoints.

### DIFF
--- a/Android.mk
+++ b/Android.mk
@@ -265,11 +265,20 @@ HYBRIS_UPDATER_UNPACK := $(LOCAL_BUILD_MODULE)
 
 .PHONY: hybris-hal hybris-common
 
-hybris-common: bootimage hybris-updater-unpack hybris-updater-script hybris-recovery hybris-boot servicemanager logcat updater init adb adbd linker libc libEGL libGLESv1_CM libGLESv2
+HYBRIS_COMMON_TARGETS := bootimage hybris-updater-unpack hybris-updater-script hybris-recovery hybris-boot servicemanager logcat updater init adb adbd linker libc libEGL libGLESv1_CM libGLESv2
+HYBRIS_COMMON_ANDROID8_TARGETS := verity_signer boot_signer e2fsdroid vendorimage ramdisk libselinux_stubs
+
+ifeq ($(shell test $(ANDROID_VERSION_MAJOR) -ge 8 && echo true),true)
+HYBRIS_COMMON_TARGETS += $(HYBRIS_COMMON_ANDROID8_TARGETS)
+endif
+
+hybris-common: $(HYBRIS_COMMON_TARGETS)
 
 ifeq ("$(TARGET_ARCH)", "arm64")
-hybris-hal: hybris-common linker_32 libc_32 libEGL_32 libGLESv1_CM_32 libGLESv2_32
+HYBRIS_TARGETS := $(HYBRIS_COMMON_TARGETS) linker_32 libc_32 libEGL_32 libGLESv1_CM_32 libGLESv2_32
 else
-hybris-hal: hybris-common
+HYBRIS_TARGETS := $(HYBRIS_COMMON_TARGETS)
 endif
+
+hybris-hal: $(HYBRIS_TARGETS)
 

--- a/Android.mk
+++ b/Android.mk
@@ -266,16 +266,21 @@ HYBRIS_UPDATER_UNPACK := $(LOCAL_BUILD_MODULE)
 .PHONY: hybris-hal hybris-common
 
 HYBRIS_COMMON_TARGETS := bootimage hybris-updater-unpack hybris-updater-script hybris-recovery hybris-boot servicemanager logcat updater init adb adbd linker libc libEGL libGLESv1_CM libGLESv2
-HYBRIS_COMMON_ANDROID8_TARGETS := verity_signer boot_signer e2fsdroid vendorimage ramdisk libselinux_stubs
+HYBRIS_COMMON_ANDROID8_TARGETS := verity_signer boot_signer e2fsdroid vendorimage ramdisk libselinux_stubs libsurfaceflinger libsf_compat_layer
 
 ifeq ($(shell test $(ANDROID_VERSION_MAJOR) -ge 8 && echo true),true)
 HYBRIS_COMMON_TARGETS += $(HYBRIS_COMMON_ANDROID8_TARGETS)
+# for 64 bit Android, also include the 32 bit variants that we need.
+HYBRIS_COMMON_64_BIT_EXTRA_TARGETS = linker_32 libc_32 libEGL_32 libGLESv1_CM_32 libGLESv2_32 libsf_compat_layer_32
+else
+# for 64 bit Android, also include the 32 bit variants that we need.
+HYBRIS_COMMON_64_BIT_EXTRA_TARGETS = linker_32 libc_32 libEGL_32 libGLESv1_CM_32 libGLESv2_32
 endif
 
 hybris-common: $(HYBRIS_COMMON_TARGETS)
 
 ifeq ("$(TARGET_ARCH)", "arm64")
-HYBRIS_TARGETS := $(HYBRIS_COMMON_TARGETS) linker_32 libc_32 libEGL_32 libGLESv1_CM_32 libGLESv2_32
+HYBRIS_TARGETS := $(HYBRIS_COMMON_TARGETS) $(HYBRIS_COMMON_64_BIT_EXTRA_TARGETS)
 else
 HYBRIS_TARGETS := $(HYBRIS_COMMON_TARGETS)
 endif

--- a/fixup-mountpoints
+++ b/fixup-mountpoints
@@ -14,6 +14,67 @@ shift
 echo "Fixing mount-points for device $DEVICE"
 
 case "$DEVICE" in
+    "pioneer")
+        sed -i \
+            -e 's block/bootdevice/by-name/LTALabel mmcblk0p7 ' \
+            -e 's block/bootdevice/by-name/Qnovo mmcblk0p75 ' \
+            -e 's block/bootdevice/by-name/TA mmcblk0p1 ' \
+            -e 's block/bootdevice/by-name/abl mmcblk0p20 ' \
+            -e 's block/bootdevice/by-name/apdp mmcblk0p52 ' \
+            -e 's block/bootdevice/by-name/appslog mmcblk0p73 ' \
+            -e 's block/bootdevice/by-name/bluetooth mmcblk0p40 ' \
+            -e 's block/bootdevice/by-name/boot mmcblk0p38 ' \
+            -e 's block/bootdevice/by-name/cdt mmcblk0p24 ' \
+            -e 's block/bootdevice/by-name/cmnlib64 mmcblk0p27 ' \
+            -e 's block/bootdevice/by-name/cmnlib mmcblk0p25 ' \
+            -e 's block/bootdevice/by-name/ddr mmcblk0p59 ' \
+            -e 's block/bootdevice/by-name/devcfg mmcblk0p29 ' \
+            -e 's block/bootdevice/by-name/devinfo mmcblk0p51 ' \
+            -e 's block/bootdevice/by-name/diag mmcblk0p74 ' \
+            -e 's block/bootdevice/by-name/dip mmcblk0p50 ' \
+            -e 's block/bootdevice/by-name/dpo mmcblk0p54 ' \
+            -e 's block/bootdevice/by-name/dsp mmcblk0p44 ' \
+            -e 's block/bootdevice/by-name/frp mmcblk0p62 ' \
+            -e 's block/bootdevice/by-name/fsc mmcblk0p3 ' \
+            -e 's block/bootdevice/by-name/fsg mmcblk0p6 ' \
+            -e 's block/bootdevice/by-name/fsmetadata mmcblk0p72 ' \
+            -e 's block/bootdevice/by-name/hyp mmcblk0p16 ' \
+            -e 's block/bootdevice/by-name/keymaster mmcblk0p22 ' \
+            -e 's block/bootdevice/by-name/keystore mmcblk0p67 ' \
+            -e 's block/bootdevice/by-name/limits mmcblk0p56 ' \
+            -e 's block/bootdevice/by-name/logfs mmcblk0p58 ' \
+            -e 's block/bootdevice/by-name/mdtp mmcblk0p48 ' \
+            -e 's block/bootdevice/by-name/mdtpsecapp mmcblk0p46 ' \
+            -e 's block/bootdevice/by-name/misc mmcblk0p64 ' \
+            -e 's block/bootdevice/by-name/modem mmcblk0p42 ' \
+            -e 's block/bootdevice/by-name/modemst1 mmcblk0p4 ' \
+            -e 's block/bootdevice/by-name/modemst2 mmcblk0p5 ' \
+            -e 's block/bootdevice/by-name/msadp mmcblk0p53 ' \
+            -e 's block/bootdevice/by-name/oem mmcblk0p68 ' \
+            -e 's block/bootdevice/by-name/persist mmcblk0p2 ' \
+            -e 's block/bootdevice/by-name/pmic mmcblk0p18 ' \
+            -e 's block/bootdevice/by-name/rddata mmcblk0p77 ' \
+            -e 's block/bootdevice/by-name/rdimage mmcblk0p65 ' \
+            -e 's block/bootdevice/by-name/rpm mmcblk0p14 ' \
+            -e 's block/bootdevice/by-name/sec mmcblk0p60 ' \
+            -e 's block/bootdevice/by-name/splash mmcblk0p55 ' \
+            -e 's block/bootdevice/by-name/ssd mmcblk0p61 ' \
+            -e 's block/bootdevice/by-name/sti mmcblk0p63 ' \
+            -e 's block/bootdevice/by-name/storsec mmcblk0p31 ' \
+            -e 's block/bootdevice/by-name/system mmcblk0p78 ' \
+            -e 's block/bootdevice/by-name/toolsfv mmcblk0p57 ' \
+            -e 's block/bootdevice/by-name/tz mmcblk0p12 ' \
+            -e 's block/bootdevice/by-name/tzxfl mmcblk0p36 ' \
+            -e 's block/bootdevice/by-name/tzxflattest mmcblk0p34 ' \
+            -e 's block/bootdevice/by-name/userdata mmcblk0p76 ' \
+            -e 's block/bootdevice/by-name/vendor mmcblk0p70 ' \
+            -e 's block/bootdevice/by-name/xbl mmcblk0p10 ' \
+            -e 's block/bootdevice/by-name/xfl mmcblk0p32 ' \
+            -e 's block/bootdevice/by-name/xflkeystore mmcblk0p8 ' \
+            -e 's block/bootdevice/by-name/xflkeystorebak mmcblk0p9 ' \
+            "$@"
+        ;;
+
     "ghost")
         sed -i \
             -e 's block/platform/msm_sdcc.1/by-name/modem mmcblk0p1 ' \

--- a/init-script
+++ b/init-script
@@ -90,6 +90,7 @@ export PATH=/bin:/sbin:/usr/bin:/usr/sbin:/usr/local/bin:/usr/local/sbin
 USB_FUNCTIONS=rndis
 
 ANDROID_USB=/sys/class/android_usb/android0
+GADGET_DIR=/config/usb_gadget
 LOCAL_IP=192.168.2.15
 
 DONE_SWITCH=no
@@ -119,6 +120,9 @@ do_mount_devprocsys()
     mkdir /sys
     mount -t sysfs sysfs /sys
     mount -t proc proc /proc
+
+    mkdir /config
+    mount -t configfs none /config
 }
 
 do_hotplug_scan()
@@ -188,25 +192,56 @@ inject_loop() {
 
 # This sets up the USB with whatever USB_FUNCTIONS are set to
 usb_setup() {
-      write $ANDROID_USB/enable        0
-      write $ANDROID_USB/functions     ""
-      write $ANDROID_USB/enable        1
-      usleep 500000 # 0.5 delay to attempt to remove rndis function
-      write $ANDROID_USB/enable        0
-      write $ANDROID_USB/idVendor      18D1
-      write $ANDROID_USB/idProduct     D001
-      write $ANDROID_USB/iManufacturer "Mer Boat Loader"
-      write $ANDROID_USB/iProduct      "$CUSTOMPRODUCT"
-      write $ANDROID_USB/iSerial       "$1"
-      write $ANDROID_USB/functions     $USB_FUNCTIONS
-      write $ANDROID_USB/enable        1
+    if [ -d $GADGET_DIR ]; then
+      G_USB_ISERIAL=$GADGET_DIR/g1/strings/0x409/serialnumber
+
+      mkdir $GADGET_DIR/g1
+      write $GADGET_DIR/g1/idVendor                   "0x18D1"
+      write $GADGET_DIR/g1/idProduct                  "0xD001"
+      mkdir $GADGET_DIR/g1/strings/0x409
+      write $GADGET_DIR/g1/strings/0x409/serialnumber "$1"
+      write $GADGET_DIR/g1/strings/0x409/manufacturer "Mer Boat Loader"
+      write $GADGET_DIR/g1/strings/0x409/product      "$CUSTOMPRODUCT"
+
+      if echo $USB_FUNCTIONS | grep -q "rndis"; then
+          mkdir $GADGET_DIR/g1/functions/rndis.usb0
+          mkdir $GADGET_DIR/g1/functions/rndis_bam.rndis
+      fi
+      echo $USB_FUNCTIONS | grep -q "mass_storage" && mkdir $GADGET_DIR/g1/functions/storage.0
+
+      mkdir $GADGET_DIR/g1/configs/c.1
+      mkdir $GADGET_DIR/g1/configs/c.1/strings/0x409
+      write $GADGET_DIR/g1/configs/c.1/strings/0x409/configuration "$USB_FUNCTIONS"
+
+      if echo $USB_FUNCTIONS | grep -q "rndis"; then
+          ln -s $GADGET_DIR/g1/functions/rndis.usb0 $GADGET_DIR/g1/configs/c.1
+          ln -s $GADGET_DIR/g1/functions/rndis_bam.rndis $GADGET_DIR/g1/configs/c.1
+      fi
+      echo $USB_FUNCTIONS | grep -q "mass_storage" && ln -s $GADGET_DIR/g1/functions/storage.0 $GADGET_DIR/g1/configs/c.1
+
+      echo "$(ls /sys/class/udc)" > $GADGET_DIR/g1/UDC
+    else
+        G_USB_ISERIAL=$ANDROID_USB/iSerial
+        write $ANDROID_USB/enable          0
+        write $ANDROID_USB/functions       ""
+        write $ANDROID_USB/enable          1
+        usleep 500000 # 0.5 delay to attempt to remove rndis function
+        write $ANDROID_USB/enable          0
+        write $ANDROID_USB/idVendor        18D1
+        write $ANDROID_USB/idProduct       D001
+        write $ANDROID_USB/iManufacturer   "Mer Boat Loader"
+        write $ANDROID_USB/iProduct        "$CUSTOMPRODUCT"
+        write $ANDROID_USB/iSerial         "$1"
+        write $ANDROID_USB/functions       $USB_FUNCTIONS
+        write $ANDROID_USB/enable          1
+    fi
 }
 # This lets us communicate errors to host (if it needs disable/enable then that's a problem)
 usb_info() {
     # make sure USB is settled
     echo "########################## usb_info: $1"
     sleep 1
-    write $ANDROID_USB/iSerial       "$1"
+    write $G_USB_ISERIAL "$1"
 }
 
 


### PR DESCRIPTION
Add support for configfs based devices, add support for android 8, add pioneer to fixup-mountpoints.

NOTE(configfs): based on @cxl000's patch, but since some devices use rndis_bam.rndis instead of rndis.usb0 this was accounted for.
NOTE(Android 8): build/ needs a different patch now. This patch is both required to minimize the build AND to make sure everything we need is actually built. The patch in build makes use of HYBRIS_TARGETS.
Due to Android 8 changes we also need to be more explicit about what we need.
NOTE(pioneer): this is the initial mountpoint information, other repositories are being prepared right now.