### PR TITLE
[pioneer] Adapt pioneer mountpoints to upstream changes. MER#1948

### DIFF
--- a/fixup-mountpoints
+++ b/fixup-mountpoints
@@ -22,7 +22,7 @@ case "$DEVICE" in
             -e 's block/bootdevice/by-name/abl mmcblk0p20 ' \
             -e 's block/bootdevice/by-name/apdp mmcblk0p52 ' \
             -e 's block/bootdevice/by-name/appslog mmcblk0p73 ' \
-            -e 's block/bootdevice/by-name/bluetooth mmcblk0p40 ' \
+            -e 's block/bootdevice/by-name/bluetooth_a mmcblk0p40 ' \
             -e 's block/bootdevice/by-name/boot mmcblk0p38 ' \
             -e 's block/bootdevice/by-name/cdt mmcblk0p24 ' \
             -e 's block/bootdevice/by-name/cmnlib64 mmcblk0p27 ' \
@@ -33,7 +33,7 @@ case "$DEVICE" in
             -e 's block/bootdevice/by-name/diag mmcblk0p74 ' \
             -e 's block/bootdevice/by-name/dip mmcblk0p50 ' \
             -e 's block/bootdevice/by-name/dpo mmcblk0p54 ' \
-            -e 's block/bootdevice/by-name/dsp mmcblk0p44 ' \
+            -e 's block/bootdevice/by-name/dsp_a mmcblk0p44 ' \
             -e 's block/bootdevice/by-name/frp mmcblk0p62 ' \
             -e 's block/bootdevice/by-name/fsc mmcblk0p3 ' \
             -e 's block/bootdevice/by-name/fsg mmcblk0p6 ' \
@@ -46,11 +46,11 @@ case "$DEVICE" in
             -e 's block/bootdevice/by-name/mdtp mmcblk0p48 ' \
             -e 's block/bootdevice/by-name/mdtpsecapp mmcblk0p46 ' \
             -e 's block/bootdevice/by-name/misc mmcblk0p64 ' \
-            -e 's block/bootdevice/by-name/modem mmcblk0p42 ' \
+            -e 's block/bootdevice/by-name/modem_a mmcblk0p42 ' \
             -e 's block/bootdevice/by-name/modemst1 mmcblk0p4 ' \
             -e 's block/bootdevice/by-name/modemst2 mmcblk0p5 ' \
             -e 's block/bootdevice/by-name/msadp mmcblk0p53 ' \
-            -e 's block/bootdevice/by-name/oem mmcblk0p68 ' \
+            -e 's block/bootdevice/by-name/oem_a mmcblk0p68 ' \
             -e 's block/bootdevice/by-name/persist mmcblk0p2 ' \
             -e 's block/bootdevice/by-name/pmic mmcblk0p18 ' \
             -e 's block/bootdevice/by-name/rddata mmcblk0p77 ' \


### PR DESCRIPTION
Needed for builds based on hybris-sony-aosp-8.1.0_r35_20180714 manifest. References https://github.com/sonyxperiadev/device-sony-nile/commit/63e997bd3a8b8f238c72ebe06a307eb8885507a6#diff-40daccd8cf511233914df004c1f9c3cc and https://github.com/mer-hybris/device-sony-nile/pull/1