### PR TITLE
Android.mk: Only build treble targets if needed

### DIFF
--- a/Android.mk
+++ b/Android.mk
@@ -276,7 +276,15 @@ else
 $(warning Skipping build of hybris-updater-script since HYBRIS_BOOT_PART is not specified)
 endif
 
-HYBRIS_COMMON_ANDROID8_TARGETS := verity_signer boot_signer e2fsdroid vendorimage ramdisk libselinux_stubs libsurfaceflinger libhwc2_compat_layer bootctl
+HYBRIS_COMMON_ANDROID8_TARGETS := e2fsdroid ramdisk libselinux_stubs libsurfaceflinger libhwc2_compat_layer
+# Legacy-partitioned devices have no need to build slotselect or vendorimage
+ifeq ($(BOARD_PROPERTY_OVERRIDES_SPLIT_ENABLED),true)
+	HYBRIS_COMMON_ANDROID8_TARGETS += vendorimage bootctl
+endif
+# Generic test if dm-verity is enabled
+ifneq ($(PRODUCT_SYSTEM_VERITY_PARTITION),)
+	HYBRIS_COMMON_ANDROID8_TARGETS += verity_signer boot_signer
+endif
 
 ifeq ($(shell test $(ANDROID_VERSION_MAJOR) -ge 8 && echo true),true)
 HYBRIS_COMMON_TARGETS += $(HYBRIS_COMMON_ANDROID8_TARGETS)


### PR DESCRIPTION
On (legacy) devices where there is only a system partition, only build `systemimage`. Only devices with with an A/B scheme need `vendorimage` and `bootctl`.

Only build `VERITY` targets if dm-verity is enabled; `PRODUCT_SYSTEM_VERITY_PARTITION` is a good test.