### PR TITLE
[cheeseburger] Update fixup-mountpoints

### DIFF
--- a/fixup-mountpoints
+++ b/fixup-mountpoints
@@ -646,7 +646,7 @@ case "$DEVICE" in
             "$@"
         ;;
   
-    "cheeseburger")
+    "cheeseburger"|"dumpling")
         sed -i \
             -e 's block/bootdevice/by-name/LOGO sde18 ' \
             -e 's block/bootdevice/by-name/abl sde16 ' \

--- a/fixup-mountpoints
+++ b/fixup-mountpoints
@@ -703,6 +703,7 @@ case "$DEVICE" in
             -e 's block/bootdevice/by-name/reserve sdd1 ' \
             -e 's block/bootdevice/by-name/reserve1 sda10 ' \
             -e 's block/bootdevice/by-name/reserve2 sda11 ' \
+            -e 's block/bootdevice/by-name/reserve3 sdf7 ' \
             -e 's block/bootdevice/by-name/rpm sde1 ' \
             -e 's block/bootdevice/by-name/rpmbak sde2 ' \
             -e 's block/bootdevice/by-name/sec sde7 ' \
@@ -716,6 +717,7 @@ case "$DEVICE" in
             -e 's block/bootdevice/by-name/tz sde3 ' \
             -e 's block/bootdevice/by-name/tzbak sde4 ' \
             -e 's block/bootdevice/by-name/userdata sda13 ' \
+            -e 's block/bootdevice/by-name/vendor sdf6 ' \
             -e 's block/bootdevice/by-name/xbl sdb1 ' \
             -e 's block/bootdevice/by-name/xblbak sdc1 ' \
             "$@"


### PR DESCRIPTION
Initial mountpoints for this device on `14.1` were added by @xreactx in the beginning of 2018: https://github.com/mer-hybris/hybris-boot/pull/120

[Treble support & /vendor partition was added by OnePlus for the phone in OxygenOS Oreo 5.1.6](https://forums.oneplus.com/threads/oxygenos-5-1-6-5-1-7-hotfix-ota-for-the-oneplus-5-5t.929455/)

[List of new partitions after the OTA is applied applied (from 5.1.5)](https://pastebin.com/i2B84kz5)

Quite literally everyone has updated past OOS 5.1.6 which released back in October 2018, the old 14.1 based port hasn't seen the light of day and my 15.1 based port has pretty much everything except call audio working right now.

[Preview pictures of the port can be found here](https://imgur.com/a/Bq3yH4q)

I'd appreciate it very much if you merge this PR, thank you :)

Best regargs,
Jami K. (deathmist on #sailfishos-porters)