### PR TITLE
selinux: Remove libselinux_stubs building.

### DIFF
--- a/Android.mk
+++ b/Android.mk
@@ -276,7 +276,7 @@ else
 $(warning Skipping build of hybris-updater-script since HYBRIS_BOOT_PART is not specified)
 endif
 
-HYBRIS_COMMON_ANDROID8_TARGETS := verity_signer boot_signer e2fsdroid vendorimage ramdisk libselinux_stubs libsurfaceflinger libhwc2_compat_layer bootctl
+HYBRIS_COMMON_ANDROID8_TARGETS := verity_signer boot_signer e2fsdroid vendorimage ramdisk libsurfaceflinger libhwc2_compat_layer bootctl
 
 ifeq ($(shell test $(ANDROID_VERSION_MAJOR) -ge 8 && echo true),true)
 HYBRIS_COMMON_TARGETS += $(HYBRIS_COMMON_ANDROID8_TARGETS)


### PR DESCRIPTION
[selinux] Remove libselinux_stubs building. JB#47185

Selinux stubs are not needed anymore when Sailfish OS has
SELinux enabled.

Signed-off-by: Matti Kosola <matti.kosola@jolla.com>