### PR TITLE
[hybris-boot] Reuse mkbootimg

### DIFF
--- a/Android.mk
+++ b/Android.mk
@@ -75,8 +75,6 @@ ifneq ($(words $(HYBRIS_DATA_PART)),1)
 $(error There should be a one and only one device entry for HYBRIS_DATA_PART)
 endif
 
-# Command used to make the image
-MKBOOTIMG := mkbootimg
 BB_STATIC := $(PRODUCT_OUT)/utilities/busybox
 
 ifneq ($(strip $(TARGET_NO_KERNEL)),true)


### PR DESCRIPTION
Android 10 doesn't allow the use of external tools and since mkbootimg
is already used inside AOSP, just resuse the rules from AOSP.

Fixes errors like: "build/make/core/Makefile:1944: error: real file "out/target/product/griffin/boot.img" depends on PHONY target "mkbootimg""