### PR TITLE
[hybris-boot]  Build only init_second_stage for Android 10+

### DIFF
--- a/Android.mk
+++ b/Android.mk
@@ -271,7 +271,15 @@ HYBRIS_UPDATER_UNPACK := $(LOCAL_BUILD_MODULE)
 
 .PHONY: hybris-hal hybris-common
 
-HYBRIS_COMMON_TARGETS := bootimage hybris-updater-unpack hybris-recovery hybris-boot servicemanager logcat updater init adb adbd linker libc libEGL libGLESv1_CM libGLESv2
+HYBRIS_INIT_TARGETS := init
+
+ifeq ($(shell test $(ANDROID_VERSION_MAJOR) -ge 10 && echo true),true)
+# init is split of into early and second stage init starting with android 10
+HYBRIS_INIT_TARGETS := init_second_stage
+endif
+
+HYBRIS_COMMON_TARGETS := bootimage hybris-updater-unpack hybris-recovery hybris-boot servicemanager logcat updater adb adbd linker libc libEGL libGLESv1_CM libGLESv2 $(HYBRIS_INIT_TARGETS)
+
 ifneq ($(HYBRIS_BOOT_PART),)
 HYBRIS_COMMON_TARGETS += hybris-updater-script
 else


### PR DESCRIPTION
Starting with Android 10 init is split up in two[1][2][3]: second and late
stage init, with one for vendor and one for system init.

[1] https://android.googlesource.com/platform/system/core/+/31438489c0e263ca39f7ba77fe4e50334f2efab7
[2] https://android.googlesource.com/platform/system/core/+/refs/tags/android-10.0.0_r6/init/Android.bp#156
[3] https://android.googlesource.com/platform/system/core/+/refs/tags/android-10.0.0_r6/init/Android.mk#60

Depends on #173

