### PR TITLE
targets for droidmedia and audioflingerglue

### DIFF
--- a/Android.mk
+++ b/Android.mk
@@ -301,3 +301,6 @@ endif
 
 hybris-hal: $(HYBRIS_TARGETS)
 
+droidmedia: $(shell external/droidmedia/detect_build_targets.sh $(PORT_ARCH) $(TARGET_ARCH))
+
+audioflingerglue: $(shell external/audioflingerglue/detect_build_targets.sh $(PORT_ARCH) $(TARGET_ARCH))

--- a/Android.mk
+++ b/Android.mk
@@ -266,7 +266,7 @@ $(LOCAL_BUILT_MODULE): $(UPDATER_UNPACK_SRC)
 	@echo "Installing updater .zip script resources."
 	mkdir -p $(dir $@)
 	rm -rf $@
-	@sed -e 's %DEVICE% $(TARGET_DEVICET) g' \
+	@sed -e 's %DEVICE% $(TARGET_DEVICE) g' \
 	     $(UPDATER_UNPACK_SRC) > $@
 
 HYBRIS_UPDATER_UNPACK := $(LOCAL_BUILD_MODULE)


### PR DESCRIPTION
Safe to use for local hadk builds, and will not inflate OBS builds as hybris-hal stays the same.