### PR TITLE
[hybris-boot] etc/init/hybris_extras.rc is used only for Android 7 an…

### DIFF
--- a/Android.mk
+++ b/Android.mk
@@ -299,6 +299,7 @@ else
 HYBRIS_TARGETS := $(HYBRIS_COMMON_TARGETS)
 endif
 
+ifeq ($(shell test $(ANDROID_VERSION_MAJOR) -ge 7 && echo true),true)
 PROVIDE_POWER_PROFILE := 1
 ifneq ($(shell find $(DEVICE_PACKAGE_OVERLAYS) -name power_profile.xml | wc -l),1)
 $(error Multiple or missing power_profile.xml files)
@@ -312,6 +313,7 @@ POWER_PROFILE := $(foreach d, $(DEVICE_PACKAGE_OVERLAYS), \
 BATTERY_CAPACITY := $(shell xmllint --xpath 'string(/device[@name="Android"]/item[@name="battery.capacity"])' $(POWER_PROFILE))
 $(shell mkdir -p $(PRODUCT_OUT)/system/etc/init)
 $(shell echo -e "on boot\n    setprop ro.hybris.battery.capacity $(BATTERY_CAPACITY)" > $(PRODUCT_OUT)/system/etc/init/hybris_extras.rc)
+endif
 endif
 
 hybris-hal: $(HYBRIS_TARGETS)


### PR DESCRIPTION
…d greater

Presence of this file for older Android versions breaks package build:

For example for hammerhead (CyanogenMod 11.0 / Android 4.4):
$ rpm/dhd/helpers/build_packages.sh

'[' 4 -ge 7 ']'
echo ''
'[' -f ./out/target/product/hammerhead/system/etc/init/hybris_extras.rc ']'
cp -a ./out/target/product/hammerhead/system/etc/init/hybris_extras.rc /media/data/port/android/installroot/usr/libexec/droid-hybris/system/etc/init/
cp: cannot create regular file `/media/data/port/android/installroot/usr/libexec/droid-hybris/system/etc/init/': No such file or directory
error: Bad exit status from /var/tmp/rpm-tmp.SrHvD1 (%install)