### PR TITLE
[hybris-boot] Add support for using fixup-mountpoint from dcd

### DIFF
--- a/Android.mk
+++ b/Android.mk
@@ -37,7 +37,8 @@ HYBRIS_R_ALWAYSDEBUG := 1
 
 # Force deferred assignment
 
-HYBRIS_FIXUP_MOUNTS := $(shell ls -1 $(LOCAL_PATH)/../fixup-mountpoints $(LOCAL_PATH)/fixup-mountpoints 2> /dev/null | head -n1)
+HYBRIS_FIXUP_MOUNTS := $(shell ls -1 $(LOCAL_PATH)/../fixup-mountpoints $(LOCAL_PATH)/../droid-configs/fixup-mountpoints-$(TARGET_DEVICE) $(LOCAL_PATH)/fixup-mountpoints 2> /dev/null | head -n1)
+$(info Found fixup mountpoint at $(HYBRIS_FIXUP_MOUNTS))
 
 
 # Find any fstab files for required partition information.


### PR DESCRIPTION
Following the hadk, the droid-configs folder for device specific
configuration will also reside in the hybris folder.  Having
fixup-mountpoint-$DEVICE in that folder will allow ports to contain all
device configuration without having to push changes up to the main
hybris-boot repository just for purpose of creating the initrd.

Change-Id: Ibc3cd7322ed916ebdd58ff1044659c491751a3f8